### PR TITLE
Added `underscore` entry_point for babel.extractors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,10 @@ setup(
         'tests': test_requires,
         'dev': dev_requires,
     },
+    entry_points="""
+    [babel.extractors]
+    underscore = django_babel_underscore:extract
+    """,
     zip_safe=False,
     license='BSD',
     keywords='django-babel-underscore',


### PR DESCRIPTION
Registered the `underscore` entry_point, as [described in the Babel documentation](http://babel.pocoo.org/docs/messages/#writing-extraction-methods).
