### PR TITLE
Extraction fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requires = [
     'django>=1.5,<2.0',
     'babel>=1.3',
     'django-babel>=0.3.9',
-    'markey>=0.7',
+    'markey>=0.8',
 ]
 
 

--- a/src/django_babel_underscore/__init__.py
+++ b/src/django_babel_underscore/__init__.py
@@ -8,7 +8,6 @@ else:
 
 from django.utils.encoding import force_text
 from django_babel.extract import extract_django
-from django.utils import six
 from markey import underscore
 from markey.tools import TokenStream
 from markey.machine import tokenize, parse_arguments
@@ -67,12 +66,8 @@ def extract(fileobj, keywords, comment_tags, options):
                     args, kwargs = parse_arguments(stream, 'gettext_end')
 
                     strings = []
-                    for arg in args:
-                        try:
-                            arg = int(arg)
-                        except ValueError:
-                            pass
-                        if isinstance(arg, six.string_types):
+                    for arg, argtype in args:
+                        if argtype == 'func_string_arg':
                             strings.append(force_text(arg))
                         else:
                             strings.append(None)


### PR DESCRIPTION
When the arguments are passed by parse_arguments, no information is keeped. But only string literals should be extracted.
I've a patch for markey (PR#3, https://github.com/EnTeQuAk/markey/pull/3) to provide the function parse_arguments returning type information as well, so that type information can be examined by caller.

I assume that markey's version is 0.8 when the feature metioned above is added.
