### PR TITLE
mroytman/add django 1.10 1.11 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,15 @@ env:
   - DJANGO_VERSION=master
   - DJANGO_VERSION=1.8.x
   - DJANGO_VERSION=1.9.x
+  - DJANGO_VERSION=1.10.x
+  - DJANGO_VERSION=1.11.x
 install:
   - pip install tox
 script:
   - tox -e "$TRAVIS_PYTHON_VERSION-$DJANGO_VERSION"
+matrix:
+  exclude:
+   - python: "2.7"
+     env: DJANGO_VERSION=master
+   - python: "pypy"
+     env: DJANGO_VERSION=master

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ universal = 1
 [metadata]
 license-file = LICENSE
 
-[pytest]
+[tools:pytest]
 python_files=test*.py
 addopts=-vs --tb=short
 timeout=5

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,6 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 import pytest
 from babel._compat import BytesIO
-from babel.messages import extract
 
 from django_babel_underscore import extract
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,4 +1,4 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 import pytest
 from babel._compat import BytesIO
 from babel.messages.extract import DEFAULT_KEYWORDS
@@ -46,4 +46,3 @@ class TestMixedExtract:
         buf = BytesIO(b'<%= _("foo") %> <%= _() %> <%= ngettext("foo", "bar", count=42) %>')
         messages = list(extract(buf, self.keywords, [], {}))
         assert messages == [(1, '_', u'foo', []), (1, '_', (), []), (1, 'ngettext', (u'foo', u'bar', None, None), [])]  # noqa
-

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,10 @@ deps18 =
     https://github.com/django/django/archive/stable/1.8.x.tar.gz#egg=django
 deps19 =
     https://github.com/django/django/archive/stable/1.9.x.tar.gz#egg=django
+deps110 =
+    https://github.com/django/django/archive/stable/1.10.x.tar.gz#egg=django
+deps111 =
+    https://github.com/django/django/archive/stable/1.11.x.tar.gz#egg=django
 master =
     https://github.com/django/django/archive/master.tar.gz#egg=django
 
@@ -21,9 +25,13 @@ deps = {[testenv]deps18}
 basepython = python2.7
 deps = {[testenv]deps19}
 
-[testenv:2.7-master]
+[testenv:2.7-1.10.x]
 basepython = python2.7
-deps = {[testenv]master}
+deps = {[testenv]deps110}
+
+[testenv:2.7-1.11.x]
+basepython = python2.7
+deps = {[testenv]deps111}
 
 [testenv:3.4-1.8.x]
 basepython = python3.4
@@ -32,6 +40,14 @@ deps = {[testenv]deps18}
 [testenv:3.4-1.9.x]
 basepython = python3.4
 deps = {[testenv]deps19}
+
+[testenv:3.4-1.10.x]
+basepython = python3.4
+deps = {[testenv]deps110}
+
+[testenv:3.4-1.11.x]
+basepython = python3.4
+deps = {[testenv]deps111}
 
 [testenv:3.4-master]
 basepython = python3.4
@@ -45,6 +61,14 @@ deps = {[testenv]deps18}
 basepython = python3.5
 deps = {[testenv]deps19}
 
+[testenv:3.5-1.10.x]
+basepython = python3.5
+deps = {[testenv]deps110}
+
+[testenv:3.5-1.11.x]
+basepython = python3.5
+deps = {[testenv]deps111}
+
 [testenv:3.5-master]
 basepython = python3.5
 deps = {[testenv]master}
@@ -57,9 +81,13 @@ deps = {[testenv]deps18}
 basepython = pypy
 deps = {[testenv]deps19}
 
-[testenv:pypy-master]
+[testenv:pypy-1.10.x]
 basepython = pypy
-deps = {[testenv]master}
+deps = {[testenv]deps110}
+
+[testenv:pypy-1.11.x]
+basepython = pypy
+deps = {[testenv]deps111}
 
 [docs]
 commands =


### PR DESCRIPTION
This PR adds tox testing for Django 1.10 and Django 1.11. It also makes some minor fixes to warnings/failures I observed while running tests locally. 

Regarding the removal of the [testenv:2.7-master] and [testenv:pypy-master] tox tests, I believe that the master branch of Django has replaced use of django.utils.lru_cache with the use of the lru_cache method of the functools Python package (in django/utils/version.py in particular). Python 2.7 does not have an lru_cache method in the functools package, and neither does PyPy, which makes them incompatible with the master branch of Django. As the master branch of Django continues to approach 2.0, it will, as expected, no longer support Python 2.7, so I have removed those tox tests.

Thank you!
